### PR TITLE
Added "blocked" as an account status, issue #1

### DIFF
--- a/isushibsiteaccess.admin.inc
+++ b/isushibsiteaccess.admin.inc
@@ -53,7 +53,7 @@ function isushibsiteaccess_settings() {
     $rows[] = array(
       'data' => array(
         check_plain($row->name),
-        $u ? t('Current') : t('Future'),
+        $u ? ($u->status ? t('Current') : t('Blocked')) : t('Future'),
         $u ? check_plain(implode(', ', $u->roles)) : $assigned_roles,
         $u ? $edit_user : $operations,
       ),


### PR DESCRIPTION
Previously, there was only two account statuses. "Current" when there was an actual user account, and "Future" when they are on the access list, but not a user account.

This pull request is a minor change that checks the status of the user account, then gives "Current" if it's an active user account, and "Blocked" when the account is blocked.

This makes it very easy to see which accounts on the access list have been blocked. Notice the second user in the enclosed screen shot.

![screen shot 2015-08-19 at 9 34 16 pm](https://cloud.githubusercontent.com/assets/8440187/9374319/62428c0a-46ba-11e5-9561-2b5fb519285b.png)
