### PR TITLE
Revoke users

### DIFF
--- a/isushibsiteaccess.admin.inc
+++ b/isushibsiteaccess.admin.inc
@@ -53,7 +53,7 @@ function isushibsiteaccess_settings() {
     $rows[] = array(
       'data' => array(
         check_plain($row->name),
-        $u ? t('Current') : t('Future'),
+        $u ? ($u->status ? t('Current') : t('Blocked')) : t('Future'),
         $u ? check_plain(implode(', ', $u->roles)) : $assigned_roles,
         $u ? $edit_user : $operations,
       ),

--- a/isushibsiteaccess.admin.inc
+++ b/isushibsiteaccess.admin.inc
@@ -354,4 +354,22 @@ function isushibsiteaccess_user_delete_confirm_submit($form, &$form_state) {
  * Form definition for bulk revoke of user access to the site.
  */
 function isushibsiteaccess_form_revoke() {
+  $form['revoke'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Revoke Users'),
+  );
+  $form['revoke']['isushibsiteaccess_usernames'] = array(
+    '#type' => 'textarea',
+    '#rows' => 2,
+    '#title' => t('Username(s) of user(s) to revoke'),
+    '#description' => t('Enter the username of a person who should no longer have access to the site. You may also provide multiple usernames delimited by commas (e.g., john, michael, ryan) or on multiple lines.')
+  );
+
+  $form['submit'] = array(
+    '#type' => 'submit',
+    '#value' => t('Submit'),
+  );
+
+  return $form;
+
 }

--- a/isushibsiteaccess.admin.inc
+++ b/isushibsiteaccess.admin.inc
@@ -381,3 +381,8 @@ function isushibsiteaccess_form_revoke_validate($form, &$form_state) {
   isushibsiteaccess_clean_and_validate_user_names($form, $form_state);
 }
 
+function isushibsiteaccess_form_revoke_submit($form, &$form_state)
+{
+	drupal_set_message(t('I am here!'));
+}
+

--- a/isushibsiteaccess.admin.inc
+++ b/isushibsiteaccess.admin.inc
@@ -349,3 +349,9 @@ function isushibsiteaccess_user_delete_confirm_submit($form, &$form_state) {
   drupal_set_message(t('Future user %name has been deleted.', array('%name' => $name)));
   $form_state['redirect'] = 'admin/config/people/isushibsiteaccess';
 }
+
+/**
+ * Form definition for bulk revoke of user access to the site.
+ */
+function isushibsiteaccess_form_revoke() {
+}

--- a/isushibsiteaccess.admin.inc
+++ b/isushibsiteaccess.admin.inc
@@ -397,6 +397,9 @@ function isushibsiteaccess_form_revoke_submit($form, &$form_state)
 	  // User exists
 	} else {
       // User doesn't exist
+      db_delete('isushibsiteaccess_users')
+        ->condition('fuid', $fuid)
+        ->execute();
     }
   }
 }

--- a/isushibsiteaccess.admin.inc
+++ b/isushibsiteaccess.admin.inc
@@ -390,6 +390,14 @@ function isushibsiteaccess_form_revoke_submit($form, &$form_state)
       form_set_error('isushibsiteaccess_nonexistant_user', t('User %name is not on the access list', array('%name' => $name)));
       continue;
     }
+    
+	$u = user_load_by_name($name);
+
+	if ($u) {
+	  // User exists
+	} else {
+      // User doesn't exist
+    }
   }
 }
 

--- a/isushibsiteaccess.admin.inc
+++ b/isushibsiteaccess.admin.inc
@@ -104,6 +104,10 @@ function isushibsiteaccess_settings() {
  * Validate user list.
  */
 function isushibsiteaccess_settings_validate($form, &$form_state) {
+  isushibsiteaccess_clean_and_validate_user_names($form, $form_state);
+}
+
+function isushibsiteaccess_clean_and_validate_user_names($form, &$form_state) {
   $users = array();
   
   // Change to an array.

--- a/isushibsiteaccess.admin.inc
+++ b/isushibsiteaccess.admin.inc
@@ -383,6 +383,9 @@ function isushibsiteaccess_form_revoke_validate($form, &$form_state) {
 
 function isushibsiteaccess_form_revoke_submit($form, &$form_state)
 {
+  $count_blocks = 0;
+  $count_deletes = 0;
+
   foreach ($form_state['values']['clean_users'] as $name) {
     // Is the user on the access list, if not, continue to the next user?
     $fuid = isushibsiteaccess_get_fuid($name);
@@ -403,6 +406,8 @@ function isushibsiteaccess_form_revoke_submit($form, &$form_state)
 	  drupal_set_message(t('Blocked existing user %name.', array('%name' => $name)));
 	  watchdog('isushibsiteaccess', 'Blocked current user %name.', array('%name' => $name));
 	  
+	  $count_blocks++;
+
 	} else {
       // Delete any roles from isushibsiteaccess
       db_delete('isushibsiteaccess_roles')
@@ -417,7 +422,17 @@ function isushibsiteaccess_form_revoke_submit($form, &$form_state)
 
       drupal_set_message(t('Deleted future user %name.', array('%name' => $name)));
 	  watchdog('isushibsiteaccess', 'Deleted user entry for %name.', array('%name' => $name));
+
+	  $count_deletes++;
     }
+  }
+
+  if ($count_blocks) {
+    drupal_set_message(t('%count current users were blocked.', array('%count' => $count_blocks)));
+  }
+
+  if ($count_deletes) {
+    drupal_set_message(t('%count future users were deleted.', array('%count' => $count_deletes)));
   }
 }
 

--- a/isushibsiteaccess.admin.inc
+++ b/isushibsiteaccess.admin.inc
@@ -383,6 +383,13 @@ function isushibsiteaccess_form_revoke_validate($form, &$form_state) {
 
 function isushibsiteaccess_form_revoke_submit($form, &$form_state)
 {
-	drupal_set_message(t('I am here!'));
+  foreach ($form_state['values']['clean_users'] as $name) {
+    // Is the user on the access list, if not, continue to the next user?
+    $fuid = isushibsiteaccess_get_fuid($name);
+    if (!$fuid) {
+      form_set_error('isushibsiteaccess_nonexistant_user', t('User %name is not on the access list', array('%name' => $name)));
+      continue;
+    }
+  }
 }
 

--- a/isushibsiteaccess.admin.inc
+++ b/isushibsiteaccess.admin.inc
@@ -385,12 +385,16 @@ function isushibsiteaccess_form_revoke_submit($form, &$form_state)
 {
   $count_blocks = 0;
   $count_deletes = 0;
+  $error_message = '';
 
   foreach ($form_state['values']['clean_users'] as $name) {
     // Is the user on the access list, if not, continue to the next user?
     $fuid = isushibsiteaccess_get_fuid($name);
     if (!$fuid) {
-      form_set_error('isushibsiteaccess_nonexistant_user', t('User %name is not on the access list', array('%name' => $name)));
+      if ($error_message != '') {
+        $error_message = $error_message . '<br />';
+      }
+      $error_message = $error_message . t('User %name is not on the access list', array('%name' => $name));
       continue;
     }
     
@@ -425,6 +429,10 @@ function isushibsiteaccess_form_revoke_submit($form, &$form_state)
 
 	  $count_deletes++;
     }
+  }
+
+  if ($error_message != '') {
+    form_set_error('isushibsiteaccess_nonexistant_user', $error_message);
   }
 
   if ($count_blocks) {

--- a/isushibsiteaccess.admin.inc
+++ b/isushibsiteaccess.admin.inc
@@ -377,3 +377,7 @@ function isushibsiteaccess_form_revoke() {
   return $form;
 
 }
+function isushibsiteaccess_form_revoke_validate($form, &$form_state) {
+  isushibsiteaccess_clean_and_validate_user_names($form, $form_state);
+}
+

--- a/isushibsiteaccess.admin.inc
+++ b/isushibsiteaccess.admin.inc
@@ -395,11 +395,28 @@ function isushibsiteaccess_form_revoke_submit($form, &$form_state)
 
 	if ($u) {
 	  // User exists
+
+      // Block the user account
+      $u->status = 0;
+	  user_save($u);
+	  
+	  drupal_set_message(t('Blocked existing user %name.', array('%name' => $name)));
+	  watchdog('isushibsiteaccess', 'Blocked current user %name.', array('%name' => $name));
+	  
 	} else {
+      // Delete any roles from isushibsiteaccess
+      db_delete('isushibsiteaccess_roles')
+        ->condition('fuid', $fuid)
+        ->execute();
+	  watchdog('isushibsiteaccess', 'deleted roles for %name', array('%name' => $name));
+
       // User doesn't exist
       db_delete('isushibsiteaccess_users')
         ->condition('fuid', $fuid)
         ->execute();
+
+      drupal_set_message(t('Deleted future user %name.', array('%name' => $name)));
+	  watchdog('isushibsiteaccess', 'Deleted user entry for %name.', array('%name' => $name));
     }
   }
 }

--- a/isushibsiteaccess.module
+++ b/isushibsiteaccess.module
@@ -31,6 +31,16 @@ function isushibsiteaccess_menu() {
     'type' => MENU_LOCAL_TASK,
     'weight' => 10,
   );
+  $items['admin/config/people/isushibsiteaccess/revoke'] = array(
+    'title' => 'Delete Users',
+    'description' => 'Bulk revoke access to the site',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('isushibsiteaccess_form_revoke'),
+    'access arguments' => array('revoke shibboleth site access'),
+    'file' => 'isushibsiteaccess.admin.inc',
+    'type' => MENU_LOCAL_TASK,
+    'weight' => 10,
+  );
   $items['admin/config/people/isushibsiteaccess/edit'] = array(
     'title' => 'Edit future user roles',
     'description' => 'Change roles that will be assigned to a given future user',


### PR DESCRIPTION
With My extension, we have approximately 1000 users in the access list, so it's kind of hard to find a user name when someone needs to be removed from the list. With this pull request, I added a delete users tab, where you can enter in a list of user names, and it will either block the user account if it exists, or remove the future user, along with rolls, from the access list.

Enclosed is an image of what the delete users tab looks like.

Brian
![screen shot 2015-08-25 at 10 13 52 am](https://cloud.githubusercontent.com/assets/8440187/9470796/2c2eba00-4b13-11e5-8d89-d3c726f7f595.png)
