### PR TITLE
Sync access list with Active Directory Group(s)

### DIFF
--- a/isushib.module
+++ b/isushib.module
@@ -338,3 +338,11 @@ function isushib_ldap_record($netid) {
   }
   return $record;
 }
+
+/**
+ * Implements hook_update_projects_alter().
+ */
+function isushib_update_projects_alter(&$projects) {
+  // Hide a site-specific module from the list.
+  unset($projects['isushib']);
+}

--- a/isushibsiteaccess.admin.inc
+++ b/isushibsiteaccess.admin.inc
@@ -53,7 +53,7 @@ function isushibsiteaccess_settings() {
     $rows[] = array(
       'data' => array(
         check_plain($row->name),
-        $u ? t('Current') : t('Future'),
+        $u ? ($u->status ? t('Current') : t('Blocked')) : t('Future'),
         $u ? check_plain(implode(', ', $u->roles)) : $assigned_roles,
         $u ? $edit_user : $operations,
       ),

--- a/isushibsiteaccesssync.admin.inc
+++ b/isushibsiteaccesssync.admin.inc
@@ -5,5 +5,46 @@
  * Configuration of Active Directory sync.
  */
 function isushibsiteaccesssync_settings() {
+  // Add form to get screenshot server URL.
+  $form['isushibsiteaccesssync'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Configure Active Directory Sync'),
+  );
 
+  $form['isushibsiteaccesssync']['isushibsiteaccesssync_ad_username'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Email Address'),
+    '#default_value' => variable_get('isushibsiteaccesssync_ad_username', ''),
+    '#description' => t('This is the email address of the account that will be used to read from Active Directory. Do not use your own account')
+  );
+
+  $form['isushibsiteaccesssync']['isushibsiteaccesssync_ad_password'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Password'),
+    '#default_value' => variable_get('isushibsiteaccesssync_ad_password', ''),
+    '#description' => t('Password for the above account. Note: this is not a secure password storage facility, so you should be using an account that has basically no rights.')
+  );
+
+  $form['isushibsiteaccesssync']['isushibsiteaccesssync_ad_group_names'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Group Name(s)'),
+    '#default_value' => variable_get('isushibsiteaccesssync_ad_group_names', ''),
+    '#description' => t('Name(s) of the groups you want to use from Active Directory. If there are more than one, use a comma to separate them. ie: cropnews, eitdev')
+  );
+
+  $form['isushibsiteaccesssync']['isushibsiteaccesssync_ad_ldap_server'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Active Domain Controller'),
+    '#default_value' => variable_get('isushibsiteaccesssync_ad_ldap_server', 'windc.iastate.edu'),
+    '#description' => t('Fully Quallified Domain Name of the AD domain controller.')
+  );
+
+  $form['isushibsiteaccesssync']['isushibsiteaccesssync_ad_ldap_dn'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Starting Distinguished Name'),
+    '#default_value' => variable_get('isushibsiteaccesssync_ad_ldap_dn', 'dc=iastate,dc=edu'),
+    '#description' => t('Starting point in Active Directory to do the search. dc=iastate,dc=edu will search the entire directory. ou=c ext,dc=iastate,dc=edu will search just the Extension OU.')
+  );
+
+  return system_settings_form($form);
 }

--- a/isushibsiteaccesssync.admin.inc
+++ b/isushibsiteaccesssync.admin.inc
@@ -15,36 +15,53 @@ function isushibsiteaccesssync_settings() {
     '#type' => 'textfield',
     '#title' => t('Email Address'),
     '#default_value' => variable_get('isushibsiteaccesssync_ad_username', ''),
-    '#description' => t('This is the email address of the account that will be used to read from Active Directory. Do not use your own account')
+    '#description' => t('This is the email address of the account that will be used to read from Active Directory. Do not use your own account'),
   );
 
   $form['isushibsiteaccesssync']['isushibsiteaccesssync_ad_password'] = array(
     '#type' => 'textfield',
     '#title' => t('Password'),
-    '#default_value' => variable_get('isushibsiteaccesssync_ad_password', ''),
-    '#description' => t('Password for the above account. Note: this is not a secure password storage facility, so you should be using an account that has basically no rights.')
+    '#default_value' => t(''),
+    '#description' => t('Password for the above account. Note: this is not a secure password storage facility, so you should be using an account that has basically no rights. This field is blank even if a password is already set, that\'s OK.'),
   );
 
   $form['isushibsiteaccesssync']['isushibsiteaccesssync_ad_group_names'] = array(
     '#type' => 'textfield',
     '#title' => t('Group Name(s)'),
     '#default_value' => variable_get('isushibsiteaccesssync_ad_group_names', ''),
-    '#description' => t('Name(s) of the groups you want to use from Active Directory. If there are more than one, use a comma to separate them. ie: cropnews, eitdev')
+    '#description' => t('Name(s) of the groups you want to use from Active Directory. If there are more than one, use a comma to separate them. ie: cropnews, eitdev'),
   );
 
   $form['isushibsiteaccesssync']['isushibsiteaccesssync_ad_ldap_server'] = array(
     '#type' => 'textfield',
     '#title' => t('Active Domain Controller'),
     '#default_value' => variable_get('isushibsiteaccesssync_ad_ldap_server', 'windc.iastate.edu'),
-    '#description' => t('Fully Quallified Domain Name of the AD domain controller.')
+    '#description' => t('Fully Quallified Domain Name of the AD domain controller.'),
   );
 
   $form['isushibsiteaccesssync']['isushibsiteaccesssync_ad_ldap_dn'] = array(
     '#type' => 'textfield',
     '#title' => t('Starting Distinguished Name'),
     '#default_value' => variable_get('isushibsiteaccesssync_ad_ldap_dn', 'dc=iastate,dc=edu'),
-    '#description' => t('Starting point in Active Directory to do the search. dc=iastate,dc=edu will search the entire directory. ou=c ext,dc=iastate,dc=edu will search just the Extension OU.')
+    '#description' => t('Starting point in Active Directory to do the search. dc=iastate,dc=edu will search the entire directory. ou=c ext,dc=iastate,dc=edu will search just the Extension OU.'),
   );
 
   return system_settings_form($form);
+}
+
+/**
+ * Validate the settings form
+ */
+function isushibsiteaccesssync_settings_validate($form, &$form_state) {
+  $saved_password = variable_get('isushibsiteaccesssync_ad_password', '');
+  $new_password = $form_state['values']['isushibsiteaccesssync_ad_password'];
+
+  if (empty($new_password)) {
+      $form_state['values']['isushibsiteaccesssync_ad_password'] = $saved_password;
+  }
+  else {
+    if ($new_password != $saved_password) {
+      $form_state['values']['isushibsiteaccesssync_ad_password'] = isushibsiteaccesssync_encrypt_string($new_password);
+    }
+  }
 }

--- a/isushibsiteaccesssync.admin.inc
+++ b/isushibsiteaccesssync.admin.inc
@@ -61,7 +61,7 @@ function isushibsiteaccesssync_settings_validate($form, &$form_state) {
   }
   else {
     if ($new_password != $saved_password) {
-      $form_state['values']['isushibsiteaccesssync_ad_password'] = isushibsiteaccesssync_encrypt_string($new_password);
+      $form_state['values']['isushibsiteaccesssync_ad_password'] = encrypt($new_password);
     }
   }
 }

--- a/isushibsiteaccesssync.admin.inc
+++ b/isushibsiteaccesssync.admin.inc
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * @file
+ * Configuration of Active Directory sync.
+ */
+function isushibsiteaccesssync_settings() {
+
+}

--- a/isushibsiteaccesssync.admin.inc
+++ b/isushibsiteaccesssync.admin.inc
@@ -19,7 +19,7 @@ function isushibsiteaccesssync_settings() {
   );
 
   $form['isushibsiteaccesssync']['isushibsiteaccesssync_ad_password'] = array(
-    '#type' => 'textfield',
+    '#type' => 'password',
     '#title' => t('Password'),
     '#default_value' => t(''),
     '#description' => t('Password for the above account. Note: this is not a secure password storage facility, so you should be using an account that has basically no rights. This field is blank even if a password is already set, that\'s OK.'),

--- a/isushibsiteaccesssync.admin.inc
+++ b/isushibsiteaccesssync.admin.inc
@@ -35,7 +35,7 @@ function isushibsiteaccesssync_settings() {
   $form['isushibsiteaccesssync']['isushibsiteaccesssync_ad_ldap_server'] = array(
     '#type' => 'textfield',
     '#title' => t('Active Domain Controller'),
-    '#default_value' => variable_get('isushibsiteaccesssync_ad_ldap_server', 'windc.iastate.edu'),
+    '#default_value' => variable_get('isushibsiteaccesssync_ad_ldap_server', 'ldaps://windc.iastate.edu:636'),
     '#description' => t('Fully Quallified Domain Name of the AD domain controller.'),
   );
 

--- a/isushibsiteaccesssync.drush.inc
+++ b/isushibsiteaccesssync.drush.inc
@@ -23,7 +23,7 @@ function isushibsiteaccesssync_drush_command() {
  * Force the sync via drush command.
  */
 function isushibsiteaccesssync_run_drush_command() {
-  variable_set('isushibsiteaccesssync_day_of_year', 0);
-  isushibsiteaccesssync_cron();
+  watchdog('isushibsiteaccesssync', 'Starting sync from drush command.');
+  isushibsiteaccesssync_main();
 }
 

--- a/isushibsiteaccesssync.drush.inc
+++ b/isushibsiteaccesssync.drush.inc
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @file
+ * Make a drush command to sync users
+ */
+
+/**
+ * Implements hook_drush_command().
+ */
+function isushibsiteaccesssync_drush_command() {
+  $items = array();
+
+  $items['sync-users'] = array(
+    'description' => 'Sync access list with Active Directory group(s)',
+    'callback' => 'isushibsiteaccesssync_run_drush_command',
+  );
+
+  return $items;
+}
+
+/**
+ * Force the sync via drush command.
+ */
+function isushibsiteaccesssync_run_drush_command() {
+  variable_set('isushibsiteaccesssync_day_of_year', 0);
+  isushibsiteaccesssync_cron();
+}
+

--- a/isushibsiteaccesssync.info
+++ b/isushibsiteaccesssync.info
@@ -1,0 +1,13 @@
+name = Shibboleth Site Access Sync
+description = Syncs the access list with Active Directory group(s).
+package = External authentication
+dependencies[] = isushib
+dependencies[] = isushibsiteaccess
+core = 7.x
+configure = admin/config/people/isushibsiteaccess
+
+; Information added by drupal.org packaging script on 2012-05-18
+version = "7.x-1.0"
+core = "7.x"
+project = "isushib"
+datestamp = "1337360188"

--- a/isushibsiteaccesssync.info
+++ b/isushibsiteaccesssync.info
@@ -3,6 +3,7 @@ description = Syncs the access list with Active Directory group(s).
 package = External authentication
 dependencies[] = isushib
 dependencies[] = isushibsiteaccess
+dependencies[] = encrypt
 core = 7.x
 configure = admin/config/people/isushibsiteaccess
 

--- a/isushibsiteaccesssync.install
+++ b/isushibsiteaccesssync.install
@@ -9,6 +9,7 @@
  * Implements hook_install().
  */
 function isushibsiteaccesssync_install() {
+  // Add status field to the isushibsiteaccess_users table
   $newfield = array(
     'description' => 'Status of username, can be AD, notAD, delete, new',
     'type' => 'varchar',
@@ -20,6 +21,13 @@ function isushibsiteaccesssync_install() {
   if (!db_field_exists('isushibsiteaccess_users', 'status')) {
     db_add_field('isushibsiteaccess_users', 'status', $newfield);
   }
+
+  // Create a random IV to use with CBC encoding / encryption
+  $iv_size = mcrypt_get_iv_size(MCRYPT_RIJNDAEL_128, MCRYPT_MODE_CBC);
+  variable_set('isushibsiteaccesssync_encryption_iv', mcrypt_create_iv($iv_size, MCRYPT_RAND));
+
+  // Create a random key for encryption
+  variable_set('isushibsiteaccesssync_encryption_key', pack('H*', bin2hex(openssl_random_pseudo_bytes(32))));
 }
 
 
@@ -45,6 +53,8 @@ function isushibsiteaccesssync_uninstall() {
   variable_del('isushibsiteaccesssync_ad_group_names');
   variable_del('isushibsiteaccesssync_ad_ldap_server');
   variable_del('isushibsiteaccesssync_ad_ldap_dn');
+  variable_del('isushibsiteaccesssync_encryption_iv');
+  variable_del('isushibsiteaccesssync_encryption_key');
 
   db_drop_field('isushibsiteaccess_users', 'status');
 }

--- a/isushibsiteaccesssync.install
+++ b/isushibsiteaccesssync.install
@@ -22,3 +22,16 @@ function isushibsiteaccesssync_install() {
   }
 }
 
+
+/**
+ * Implements hook_schema_alter().
+ */
+function isushibsiteaccesssync_schema_alter(&$schema) {
+  $schema['isushibsiteaccess_users']['fields']['status'] = array(
+    'description' => 'Status of username, can be AD, notAD, delete, new',
+    'type' => 'varchar',
+    'length' => '60',
+    'not null' => TRUE,
+    'default' => 'notAD',
+  );
+}

--- a/isushibsiteaccesssync.install
+++ b/isushibsiteaccesssync.install
@@ -11,7 +11,7 @@
 function isushibsiteaccesssync_install() {
   // Add status field to the isushibsiteaccess_users table
   $newfield = array(
-    'description' => 'Status of username, can be AD, notAD, delete, new',
+    'description' => 'Tells whether the user came from Active Directory or not.',
     'type' => 'varchar',
     'length' => '60',
     'not null' => TRUE,
@@ -36,7 +36,7 @@ function isushibsiteaccesssync_install() {
  */
 function isushibsiteaccesssync_schema_alter(&$schema) {
   $schema['isushibsiteaccess_users']['fields']['status'] = array(
-    'description' => 'Status of username, can be AD, notAD, delete, new',
+    'description' => 'Tells whether the user came from Active Directory or not.',
     'type' => 'varchar',
     'length' => '60',
     'not null' => TRUE,

--- a/isushibsiteaccesssync.install
+++ b/isushibsiteaccesssync.install
@@ -21,13 +21,6 @@ function isushibsiteaccesssync_install() {
   if (!db_field_exists('isushibsiteaccess_users', 'status')) {
     db_add_field('isushibsiteaccess_users', 'status', $newfield);
   }
-
-  // Create a random IV to use with CBC encoding / encryption
-  $iv_size = mcrypt_get_iv_size(MCRYPT_RIJNDAEL_128, MCRYPT_MODE_CBC);
-  variable_set('isushibsiteaccesssync_encryption_iv', mcrypt_create_iv($iv_size, MCRYPT_RAND));
-
-  // Create a random key for encryption
-  variable_set('isushibsiteaccesssync_encryption_key', pack('H*', bin2hex(openssl_random_pseudo_bytes(32))));
 }
 
 
@@ -53,8 +46,6 @@ function isushibsiteaccesssync_uninstall() {
   variable_del('isushibsiteaccesssync_ad_group_names');
   variable_del('isushibsiteaccesssync_ad_ldap_server');
   variable_del('isushibsiteaccesssync_ad_ldap_dn');
-  variable_del('isushibsiteaccesssync_encryption_iv');
-  variable_del('isushibsiteaccesssync_encryption_key');
   variable_del('isushibsiteaccesssync_last_run');
 
   db_drop_field('isushibsiteaccess_users', 'status');

--- a/isushibsiteaccesssync.install
+++ b/isushibsiteaccesssync.install
@@ -4,3 +4,21 @@
  * @file
  * Installation file for shibboleth site access sync module.
  */
+
+/**
+ * Implements hook_install().
+ */
+function isushibsiteaccesssync_install() {
+  $newfield = array(
+    'description' => 'Status of username, can be AD, notAD, delete, new',
+    'type' => 'varchar',
+    'length' => '60',
+    'not null' => TRUE,
+    'default' => 'notAD',
+  );
+
+  if (!db_field_exists('isushibsiteaccess_users', 'status')) {
+    db_add_field('isushibsiteaccess_users', 'status', $newfield);
+  }
+}
+

--- a/isushibsiteaccesssync.install
+++ b/isushibsiteaccesssync.install
@@ -35,3 +35,16 @@ function isushibsiteaccesssync_schema_alter(&$schema) {
     'default' => 'notAD',
   );
 }
+
+/**
+ * Implements hook_uninstall().
+ */
+function isushibsiteaccesssync_uninstall() {
+  variable_del('isushibsiteaccesssync_ad_username');
+  variable_del('isushibsiteaccesssync_ad_password');
+  variable_del('isushibsiteaccesssync_ad_group_names');
+  variable_del('isushibsiteaccesssync_ad_ldap_server');
+  variable_del('isushibsiteaccesssync_ad_ldap_dn');
+
+  db_drop_field('isushibsiteaccess_users', 'status');
+}

--- a/isushibsiteaccesssync.install
+++ b/isushibsiteaccesssync.install
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * @file
+ * Installation file for shibboleth site access sync module.
+ */

--- a/isushibsiteaccesssync.install
+++ b/isushibsiteaccesssync.install
@@ -55,6 +55,7 @@ function isushibsiteaccesssync_uninstall() {
   variable_del('isushibsiteaccesssync_ad_ldap_dn');
   variable_del('isushibsiteaccesssync_encryption_iv');
   variable_del('isushibsiteaccesssync_encryption_key');
+  variable_del('isushibsiteaccesssync_day_of_year');
 
   db_drop_field('isushibsiteaccess_users', 'status');
 }

--- a/isushibsiteaccesssync.install
+++ b/isushibsiteaccesssync.install
@@ -55,7 +55,7 @@ function isushibsiteaccesssync_uninstall() {
   variable_del('isushibsiteaccesssync_ad_ldap_dn');
   variable_del('isushibsiteaccesssync_encryption_iv');
   variable_del('isushibsiteaccesssync_encryption_key');
-  variable_del('isushibsiteaccesssync_day_of_year');
+  variable_del('isushibsiteaccesssync_last_run');
 
   db_drop_field('isushibsiteaccess_users', 'status');
 }

--- a/isushibsiteaccesssync.module
+++ b/isushibsiteaccesssync.module
@@ -38,6 +38,9 @@ function isushibsiteaccesssync_cron() {
  * Sync the lists
  */
 function isushibsiteaccesssync_main() {
+  // Set last run variable_get
+  variable_set('isushibsiteaccesssync_last_run', date('Ymd'));
+
   // Read some variables
   $ad_username = variable_get('isushibsiteaccesssync_ad_username', '');
   $ad_password = trim(decrypt(variable_get('isushibsiteaccesssync_ad_password', '')));
@@ -113,7 +116,6 @@ function isushibsiteaccesssync_main() {
 
   ldap_close($directory_service);
 
-  variable_set('isushibsiteaccesssync_last_run', date('Ymd'));
   watchdog('isushibsiteaccesssync', 'Finished syncing users from AD group(s).');
 }
 

--- a/isushibsiteaccesssync.module
+++ b/isushibsiteaccesssync.module
@@ -70,6 +70,8 @@ function isushibsiteaccesssync_cron() {
     }
 
   }
+
+  isushibsiteaccesssync_revoke_users();
 }
 
 /**
@@ -107,5 +109,44 @@ function isushibsiteaccesssync_handle_user($username) {
       'status' => 'AD',
     );
     drupal_write_record('isushibsiteaccess_users', $record);
+  }
+}
+
+/**
+ * Revoke access to anyone who's status is still Delete
+ */
+function isushibsiteaccesssync_revoke_users() {
+  // Select the records where status = Delete
+  $query = db_select('isushibsiteaccess_users', 'pu')
+    ->fields('pu', array('fuid', 'name', 'status'))
+    ->condition('status', 'Delete', '=');
+  $results = $query->execute();
+
+  foreach ($results as $row) {
+    $u = user_load_by_name($row->name);
+
+    if ($u) {
+      // User exists, block the user account
+      if ($u->status != 0) {
+        $u->status = 0;
+        user_save($u);
+
+        watchdog('isushibsiteaccesssync', 'Blocked current user %name.', array('%name' => $row->name));
+      }
+    }
+    else {
+      // User doesn't exist, delete any roles from isushibsiteaccess
+      db_delete('isushibsiteaccess_roles')
+        ->condition('fuid', $row->fuid, '=')
+        ->execute();
+      watchdog('isushibsiteaccesssync', 'Deleted roles for %name.', array('%name' => $row->name));
+
+      // Delete the entry from isushibsiteaccess_users
+      db_delete('isushibsiteaccess_users')
+        ->condition('fuid', $row->fuid, '=')
+        ->execute();
+
+      watchdog('isushibsiteaccesssync', 'Deleted user entry for %name.', array('%name' => $row->name));
+    }
   }
 }

--- a/isushibsiteaccesssync.module
+++ b/isushibsiteaccesssync.module
@@ -63,7 +63,10 @@ function isushibsiteaccesssync_cron() {
 
     // Handle each member of the group
     foreach ($group_membership as $key => $value) {
-      watchdog('isushibsiteaccesssync', '%key: %name', array('%key' => $key, '%name' => $value));
+      $username = str_replace('CN=', '', $value);
+      $username = substr($username, 0, stripos($username, ','));
+
+      isushibsiteaccesssync_handle_user($username);
     }
 
   }
@@ -74,7 +77,35 @@ function isushibsiteaccesssync_cron() {
  */
 function isushibsiteaccesssync_mark_users_to_delete() {
   db_update('isushibsiteaccess_users')
-    ->fields(array('status' => 'AD'))
-    ->condition('status', 'Delete', '=')
+    ->fields(array('status' => 'Delete'))
+    ->condition('status', 'AD', '=')
     ->execute();
+}
+
+/**
+ * Make sure the user has access
+ */
+function isushibsiteaccesssync_handle_user($username) {
+  // Select the user's record
+  $query = db_select('isushibsiteaccess_users', 'pu')
+    ->fields('pu', array('fuid', 'name', 'status'))
+    ->condition('name', $username, '=');
+  $results = $query->execute();
+
+  // Check if the user exists
+  if ($results->rowCount() == 1) {
+    //Update the status
+    $num_updated = db_update('isushibsiteaccess_users')
+      ->fields(array('status' => 'AD'))
+      ->condition('name', $username, '=')
+      ->execute();
+  }
+  else {
+    // Add user record.
+    $record = array(
+      'name' => $username,
+      'status' => 'AD',
+    );
+    drupal_write_record('isushibsiteaccess_users', $record);
+  }
 }

--- a/isushibsiteaccesssync.module
+++ b/isushibsiteaccesssync.module
@@ -21,7 +21,13 @@ function isushibsiteaccesssync_cron() {
   if ($ad_username == '' || $ad_password == '' || empty($ad_group_names)) {
     return;
   }
-  
+
+  // Make sure we have LDAP extensions installed
+  if (!function_exists('ldap_connect')) {
+    watchdog('isushibsiteaccesssync', 'PHP LDAP extensions not installed, exiting.');
+    return;
+  }
+
   $ad_group_names = array_map('trim', $ad_group_names);
   foreach ($ad_group_names as $ad_group_name) {
     watchdog('isushibsiteaccesssync', t('*%name*', array('%name' => $ad_group_name)));

--- a/isushibsiteaccesssync.module
+++ b/isushibsiteaccesssync.module
@@ -36,6 +36,7 @@ function isushibsiteaccesssync_cron() {
   // Exit if we don't have the variables that we need.
   $ad_group_names = array_filter($ad_group_names);
   if ($ad_username == '' || $ad_password == '' || empty($ad_group_names)) {
+    watchdog('isushibsiteaccesssync', 'Missing variables. Configure AD Sync to allow module to work.');
     return;
   }
 

--- a/isushibsiteaccesssync.module
+++ b/isushibsiteaccesssync.module
@@ -4,3 +4,21 @@
  * @file
  * Syncs the access list with Active Directory group(s).
  */
+
+
+/**
+ * Implements hook_cron().
+ */
+function isushibsiteaccess_cron() {
+  $ad_username = variable_get('isushibsiteaccesssync_ad_username', '');
+  $ad_password = variable_get('isushibsiteaccesssync_ad_password', '');
+  $ad_group_names = variable_get('isushibsiteaccesssync_ad_group_names', '');
+  $ad_ldap_server = variable_get('isushibsiteaccesssync_ad_ldap_server', 'windc.iastate.edu');
+  $ad_ldap_dn = variable_get('isushibsiteaccesssync_ad_ldap_dn', 'dc=iastate,dc=edu');
+
+  // Exit if we don't have the variables that we need.
+  if ($ad_username == '' || $ad_password == '' || $ad_group_names == '') {
+    return;
+  }
+  watchdog('isushibsiteaccesssync', 'In cron');
+}

--- a/isushibsiteaccesssync.module
+++ b/isushibsiteaccesssync.module
@@ -56,7 +56,10 @@ function isushibsiteaccesssync_cron() {
   // Set some LDAP options
   ldap_set_option($directory_service, LDAP_OPT_REFERRALS, 0);
   ldap_set_option($directory_service, LDAP_OPT_PROTOCOL_VERSION, 3);
-  ldap_bind($directory_service, $ad_username, $ad_password);
+  if (!ldap_bind($directory_service, $ad_username, $ad_password)) {
+    watchdog('isushibsiteaccesssync', 'Unable to login to read from Active Directory');
+    return;
+  }
 
   isushibsiteaccesssync_mark_users_to_delete();
 

--- a/isushibsiteaccesssync.module
+++ b/isushibsiteaccesssync.module
@@ -28,8 +28,41 @@ function isushibsiteaccesssync_cron() {
     return;
   }
 
+  // Make sure we can connet to the LDAP server
+  $directory_service = ldap_connect($ad_ldap_server);
+  if (!$directory_service) {
+    watchdog('isushibsiteaccesssync', 'Could not connect to LDAP server.');
+    return;
+  }
+
+
+  // Set some LDAP options
+  ldap_set_option($directory_service, LDAP_OPT_REFERRALS, 0);
+  ldap_set_option($directory_service, LDAP_OPT_PROTOCOL_VERSION, 3);
+  ldap_bind($directory_service, $ad_username, $ad_password);
+
   $ad_group_names = array_map('trim', $ad_group_names);
   foreach ($ad_group_names as $ad_group_name) {
-    watchdog('isushibsiteaccesssync', t('*%name*', array('%name' => $ad_group_name)));
+
+    // Do the actual search
+    $search_term = '(cn=' . $ad_group_name . ')';
+    $sr = ldap_search($directory_service, $ad_ldap_dn, $search_term);
+    $info = ldap_get_entries($directory_service, $sr);
+
+    // Check that we found something
+    if ($info['count'] == 0) {
+      watchdog('isushibsiteaccesssync', 'Can not read from %name.', array('%name' => $ad_group_name));
+      continue;
+    }
+
+    // One key pair is the count, don't need to keep this
+    $group_membership = $info[0]['member'];
+    unset($group_membership['count']);
+
+    // Handle each member of the group
+    foreach ($group_membership as $key => $value) {
+      watchdog('isushibsiteaccesssync', '%key: %name', array('%key' => $key, '%name' => $value));
+    }
+
   }
 }

--- a/isushibsiteaccesssync.module
+++ b/isushibsiteaccesssync.module
@@ -126,6 +126,8 @@ function isushibsiteaccesssync_handle_user($username) {
       'status' => 'AD',
     );
     drupal_write_record('isushibsiteaccess_users', $record);
+
+    watchdog('isushibsiteaccesssync', 'Added user %name', array('%name' => $username));
   }
 }
 

--- a/isushibsiteaccesssync.module
+++ b/isushibsiteaccesssync.module
@@ -40,7 +40,7 @@ function isushibsiteaccesssync_cron() {
 function isushibsiteaccesssync_main() {
   // Read some variables
   $ad_username = variable_get('isushibsiteaccesssync_ad_username', '');
-  $ad_password = trim(isushibsiteaccesssync_decrypt_string(variable_get('isushibsiteaccesssync_ad_password', '')));
+  $ad_password = trim(decrypt(variable_get('isushibsiteaccesssync_ad_password', '')));
   $ad_group_names = explode(',', variable_get('isushibsiteaccesssync_ad_group_names', ''));
   $ad_ldap_server = variable_get('isushibsiteaccesssync_ad_ldap_server', 'windc.iastate.edu');
   $ad_ldap_dn = variable_get('isushibsiteaccesssync_ad_ldap_dn', 'dc=iastate,dc=edu');
@@ -195,24 +195,4 @@ function isushibsiteaccesssync_revoke_users() {
     }
   }
 }
-
-/**
- * Returns an encrypted string
- */
-function isushibsiteaccesssync_encrypt_string($plaintext) {
-  // creates a cipher text compatible with AES (Rijndael block size = 128)
-  // to keep the text confidential
-  // only suitable for encoded input that never ends with value 00h
-  // (because of default zero padding)
-  return mcrypt_encrypt(MCRYPT_RIJNDAEL_128, variable_get('isushibsiteaccesssync_encryption_key', ''), $plaintext, MCRYPT_MODE_CBC, variable_get('isushibsiteaccesssync_encryption_iv', ''));
-}
-
-/**
- * Returns a decrypted string
- */
-function isushibsiteaccesssync_decrypt_string($encrypted_string) {
-  // may remove 00h valued characters from end of plain text
-  return mcrypt_decrypt(MCRYPT_RIJNDAEL_128, variable_get('isushibsiteaccesssync_encryption_key', ''), $encrypted_string, MCRYPT_MODE_CBC, variable_get('isushibsiteaccesssync_encryption_iv', ''));
-}
-
 

--- a/isushibsiteaccesssync.module
+++ b/isushibsiteaccesssync.module
@@ -32,6 +32,16 @@ function isushibsiteaccesssync_cron() {
     return;
   }
 
+  watchdog('isushibsiteaccesssync', 'Starting sync from cron.');
+  isushibsiteaccesssync_main();
+
+  variable_set('isushibsiteaccesssync_day_of_year', date('z') + 1);
+}
+
+/**
+ * Sync the lists
+ */
+function isushibsiteaccesssync_main() {
   // Read some variables
   $ad_username = variable_get('isushibsiteaccesssync_ad_username', '');
   $ad_password = trim(isushibsiteaccesssync_decrypt_string(variable_get('isushibsiteaccesssync_ad_password', '')));
@@ -106,7 +116,7 @@ function isushibsiteaccesssync_cron() {
       ->execute();
 
   ldap_close($directory_service);
-  variable_set('isushibsiteaccesssync_day_of_year', date('z') + 1);
+
   watchdog('isushibsiteaccesssync', 'Finished syncing users from AD group(s).');
 }
 

--- a/isushibsiteaccesssync.module
+++ b/isushibsiteaccesssync.module
@@ -28,14 +28,10 @@ function isushibsiteaccesssync_menu() {
  */
 function isushibsiteaccesssync_cron() {
   // Only run this once per day
-  if (variable_get('isushibsiteaccesssync_day_of_year', 0) == date('z') + 1) {
-    return;
+  if (variable_get('isushibsiteaccesssync_last_run', '20150101') < date('Ymd')) {
+    watchdog('isushibsiteaccesssync', 'Starting sync from cron.');
+    isushibsiteaccesssync_main();
   }
-
-  watchdog('isushibsiteaccesssync', 'Starting sync from cron.');
-  isushibsiteaccesssync_main();
-
-  variable_set('isushibsiteaccesssync_day_of_year', date('z') + 1);
 }
 
 /**
@@ -117,6 +113,7 @@ function isushibsiteaccesssync_main() {
 
   ldap_close($directory_service);
 
+  variable_set('isushibsiteaccesssync_last_run', date('Ymd'));
   watchdog('isushibsiteaccesssync', 'Finished syncing users from AD group(s).');
 }
 

--- a/isushibsiteaccesssync.module
+++ b/isushibsiteaccesssync.module
@@ -28,7 +28,7 @@ function isushibsiteaccesssync_menu() {
  */
 function isushibsiteaccesssync_cron() {
   $ad_username = variable_get('isushibsiteaccesssync_ad_username', '');
-  $ad_password = variable_get('isushibsiteaccesssync_ad_password', '');
+  $ad_password = trim(isushibsiteaccesssync_decrypt_string(variable_get('isushibsiteaccesssync_ad_password', '')));
   $ad_group_names = explode(',', variable_get('isushibsiteaccesssync_ad_group_names', ''));
   $ad_ldap_server = variable_get('isushibsiteaccesssync_ad_ldap_server', 'windc.iastate.edu');
   $ad_ldap_dn = variable_get('isushibsiteaccesssync_ad_ldap_dn', 'dc=iastate,dc=edu');
@@ -174,3 +174,31 @@ function isushibsiteaccesssync_revoke_users() {
     }
   }
 }
+
+/**
+ * Return a binary key for encryption
+ */
+function isushibsiteaccesssync_get_encryption_key() {
+  return pack('H*', 'ad4e53fead34d289adee7432cd3a432e4b4532dff32889323d44dc342ac32d32');
+}
+
+/**
+ * Returns an encrypted string
+ */
+function isushibsiteaccesssync_encrypt_string($plaintext) {
+  // creates a cipher text compatible with AES (Rijndael block size = 128)
+  // to keep the text confidential
+  // only suitable for encoded input that never ends with value 00h
+  // (because of default zero padding)
+  return mcrypt_encrypt(MCRYPT_RIJNDAEL_128, variable_get('isushibsiteaccesssync_encryption_key', ''), $plaintext, MCRYPT_MODE_CBC, variable_get('isushibsiteaccesssync_encryption_iv', ''));
+}
+
+/**
+ * Returns a decrypted string
+ */
+function isushibsiteaccesssync_decrypt_string($encrypted_string) {
+  // may remove 00h valued characters from end of plain text
+  return mcrypt_decrypt(MCRYPT_RIJNDAEL_128, variable_get('isushibsiteaccesssync_encryption_key', ''), $encrypted_string, MCRYPT_MODE_CBC, variable_get('isushibsiteaccesssync_encryption_iv', ''));
+}
+
+

--- a/isushibsiteaccesssync.module
+++ b/isushibsiteaccesssync.module
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * @file
+ * Syncs the access list with Active Directory group(s).
+ */

--- a/isushibsiteaccesssync.module
+++ b/isushibsiteaccesssync.module
@@ -11,7 +11,7 @@
  */
 function isushibsiteaccesssync_menu() {
   $items['admin/config/people/isushibsiteaccesssync'] = array(
-    'title' => 'Configure AD Sync',
+    'title' => 'Active Directory Sync',
     'description' => 'Edit settings for Active Directory sync.',
     'page callback' => 'drupal_get_form',
     'page arguments' => array('isushibsiteaccesssync_settings'),

--- a/isushibsiteaccesssync.module
+++ b/isushibsiteaccesssync.module
@@ -41,10 +41,10 @@ function isushibsiteaccesssync_cron() {
   ldap_set_option($directory_service, LDAP_OPT_PROTOCOL_VERSION, 3);
   ldap_bind($directory_service, $ad_username, $ad_password);
 
-  $ad_group_names = array_map('trim', $ad_group_names);
   foreach ($ad_group_names as $ad_group_name) {
 
     // Do the actual search
+    $ad_group_name = trim($ad_group_name);
     $search_term = '(cn=' . $ad_group_name . ')';
     $sr = ldap_search($directory_service, $ad_ldap_dn, $search_term);
     $info = ldap_get_entries($directory_service, $sr);

--- a/isushibsiteaccesssync.module
+++ b/isushibsiteaccesssync.module
@@ -9,7 +9,7 @@
 /**
  * Implements hook_cron().
  */
-function isushibsiteaccess_cron() {
+function isushibsiteaccesssync_cron() {
   $ad_username = variable_get('isushibsiteaccesssync_ad_username', '');
   $ad_password = variable_get('isushibsiteaccesssync_ad_password', '');
   $ad_group_names = variable_get('isushibsiteaccesssync_ad_group_names', '');

--- a/isushibsiteaccesssync.module
+++ b/isushibsiteaccesssync.module
@@ -133,13 +133,13 @@ function isushibsiteaccesssync_mark_users_to_delete() {
  * Make sure the user has access
  */
 function isushibsiteaccesssync_handle_user($username) {
-  // Select the user's record
+  // Select the user's record in isushibsiteaccess_users
   $query = db_select('isushibsiteaccess_users', 'pu')
     ->fields('pu', array('fuid', 'name', 'status'))
     ->condition('name', $username, '=');
   $results = $query->execute();
 
-  // Check if the user exists
+  // Check if the record exists in isushibsiteaccess_users
   if ($results->rowCount() == 1) {
     //Update the status
     $num_updated = db_update('isushibsiteaccess_users')
@@ -156,6 +156,18 @@ function isushibsiteaccesssync_handle_user($username) {
     drupal_write_record('isushibsiteaccess_users', $record);
 
     watchdog('isushibsiteaccesssync', 'Added user %name', array('%name' => $username));
+  }
+
+  // Check if the user account exists in Drupal, and if so, make sure it is not blocked
+  $u = user_load_by_name($username);
+  if ($u) {
+    if ($u->status == 0) {
+      db_update('users')
+        ->fields(array('status' => 1))
+        ->condition('name', $username, '=')
+        ->execute();
+      watchdog('isushibsiteaccesssync', 'Unblocked user %name', array('%name' => $username));
+    }
   }
 }
 

--- a/isushibsiteaccesssync.module
+++ b/isushibsiteaccesssync.module
@@ -41,6 +41,8 @@ function isushibsiteaccesssync_cron() {
   ldap_set_option($directory_service, LDAP_OPT_PROTOCOL_VERSION, 3);
   ldap_bind($directory_service, $ad_username, $ad_password);
 
+  isushibsiteaccesssync_mark_users_to_delete();
+
   foreach ($ad_group_names as $ad_group_name) {
 
     // Do the actual search
@@ -65,4 +67,14 @@ function isushibsiteaccesssync_cron() {
     }
 
   }
+}
+
+/**
+ * Mark all AD users to delete.
+ */
+function isushibsiteaccesssync_mark_users_to_delete() {
+  db_update('isushibsiteaccess_users')
+    ->fields(array('status' => 'AD'))
+    ->condition('status', 'Delete', '=')
+    ->execute();
 }

--- a/isushibsiteaccesssync.module
+++ b/isushibsiteaccesssync.module
@@ -21,5 +21,9 @@ function isushibsiteaccesssync_cron() {
   if ($ad_username == '' || $ad_password == '' || empty($ad_group_names)) {
     return;
   }
-  watchdog('isushibsiteaccesssync', 'In cron');
+  
+  $ad_group_names = array_map('trim', $ad_group_names);
+  foreach ($ad_group_names as $ad_group_name) {
+    watchdog('isushibsiteaccesssync', t('*%name*', array('%name' => $ad_group_name)));
+  }
 }

--- a/isushibsiteaccesssync.module
+++ b/isushibsiteaccesssync.module
@@ -7,6 +7,23 @@
 
 
 /**
+ * Implements hook_menu().
+ */
+function isushibsiteaccesssync_menu() {
+  $items['admin/config/people/isushibsiteaccesssync'] = array(
+    'title' => 'Configure AD Sync',
+    'description' => 'Edit settings for Active Directory sync.',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('isushibsiteaccesssync_settings'),
+    'access arguments' => array('administer shibboleth site access ad sync'),
+    'file' => 'isushibsiteaccesssync.admin.inc',
+  );
+
+  return $items;
+}
+
+
+/**
  * Implements hook_cron().
  */
 function isushibsiteaccesssync_cron() {

--- a/isushibsiteaccesssync.module
+++ b/isushibsiteaccesssync.module
@@ -12,12 +12,13 @@
 function isushibsiteaccesssync_cron() {
   $ad_username = variable_get('isushibsiteaccesssync_ad_username', '');
   $ad_password = variable_get('isushibsiteaccesssync_ad_password', '');
-  $ad_group_names = variable_get('isushibsiteaccesssync_ad_group_names', '');
+  $ad_group_names = explode(',', variable_get('isushibsiteaccesssync_ad_group_names', ''));
   $ad_ldap_server = variable_get('isushibsiteaccesssync_ad_ldap_server', 'windc.iastate.edu');
   $ad_ldap_dn = variable_get('isushibsiteaccesssync_ad_ldap_dn', 'dc=iastate,dc=edu');
 
   // Exit if we don't have the variables that we need.
-  if ($ad_username == '' || $ad_password == '' || $ad_group_names == '') {
+  $ad_group_names = array_filter($ad_group_names);
+  if ($ad_username == '' || $ad_password == '' || empty($ad_group_names)) {
     return;
   }
   watchdog('isushibsiteaccesssync', 'In cron');

--- a/isushibsiteaccesssync.module
+++ b/isushibsiteaccesssync.module
@@ -93,6 +93,7 @@ function isushibsiteaccesssync_cron() {
   }
 
   isushibsiteaccesssync_revoke_users();
+  ldap_close($directory_service);
 }
 
 /**

--- a/isushibsiteaccesssync.module
+++ b/isushibsiteaccesssync.module
@@ -93,6 +93,12 @@ function isushibsiteaccesssync_cron() {
   }
 
   isushibsiteaccesssync_revoke_users();
+
+  db_update('isushibsiteaccess_users')
+      ->fields(array('status' => 'notAD'))
+      ->condition('status', 'Delete', '=')
+      ->execute();
+
   ldap_close($directory_service);
 }
 

--- a/isushibsiteaccesssync.module
+++ b/isushibsiteaccesssync.module
@@ -27,6 +27,13 @@ function isushibsiteaccesssync_menu() {
  * Implements hook_cron().
  */
 function isushibsiteaccesssync_cron() {
+  // Only run this once per day
+  if (variable_get('isushibsiteaccesssync_day_of_year', 0) == date('z') + 1) {
+    return;
+  }
+  variable_set('isushibsiteaccesssync_day_of_year', date('z') + 1);
+
+  // Read some variables
   $ad_username = variable_get('isushibsiteaccesssync_ad_username', '');
   $ad_password = trim(isushibsiteaccesssync_decrypt_string(variable_get('isushibsiteaccesssync_ad_password', '')));
   $ad_group_names = explode(',', variable_get('isushibsiteaccesssync_ad_group_names', ''));
@@ -100,6 +107,8 @@ function isushibsiteaccesssync_cron() {
       ->execute();
 
   ldap_close($directory_service);
+
+  watchdog('isushibsiteaccesssync', 'Finished syncing users from AD group(s).');
 }
 
 /**

--- a/isushibsiteaccesssync.module
+++ b/isushibsiteaccesssync.module
@@ -190,13 +190,6 @@ function isushibsiteaccesssync_revoke_users() {
 }
 
 /**
- * Return a binary key for encryption
- */
-function isushibsiteaccesssync_get_encryption_key() {
-  return pack('H*', 'ad4e53fead34d289adee7432cd3a432e4b4532dff32889323d44dc342ac32d32');
-}
-
-/**
  * Returns an encrypted string
  */
 function isushibsiteaccesssync_encrypt_string($plaintext) {

--- a/isushibsiteaccesssync.module
+++ b/isushibsiteaccesssync.module
@@ -31,7 +31,6 @@ function isushibsiteaccesssync_cron() {
   if (variable_get('isushibsiteaccesssync_day_of_year', 0) == date('z') + 1) {
     return;
   }
-  variable_set('isushibsiteaccesssync_day_of_year', date('z') + 1);
 
   // Read some variables
   $ad_username = variable_get('isushibsiteaccesssync_ad_username', '');
@@ -107,7 +106,7 @@ function isushibsiteaccesssync_cron() {
       ->execute();
 
   ldap_close($directory_service);
-
+  variable_set('isushibsiteaccesssync_day_of_year', date('z') + 1);
   watchdog('isushibsiteaccesssync', 'Finished syncing users from AD group(s).');
 }
 

--- a/isushibsiteaccesssync.module
+++ b/isushibsiteaccesssync.module
@@ -42,7 +42,7 @@ function isushibsiteaccesssync_main() {
   $ad_username = variable_get('isushibsiteaccesssync_ad_username', '');
   $ad_password = trim(decrypt(variable_get('isushibsiteaccesssync_ad_password', '')));
   $ad_group_names = explode(',', variable_get('isushibsiteaccesssync_ad_group_names', ''));
-  $ad_ldap_server = variable_get('isushibsiteaccesssync_ad_ldap_server', 'windc.iastate.edu');
+  $ad_ldap_server = variable_get('isushibsiteaccesssync_ad_ldap_server', 'ldaps://windc.iastate.edu:636');
   $ad_ldap_dn = variable_get('isushibsiteaccesssync_ad_ldap_dn', 'dc=iastate,dc=edu');
 
   // Exit if we don't have the variables that we need.


### PR DESCRIPTION
This is a new module, isushibsiteaccesssync, that modifies the access list used by isushibsiteaccess. It reads membership of group(s) in Active Directory (AD), to set the access list accordingly.

It adds a status field to the isushibsiteaccess_users table. It uses this field to track which users are from AD. This allows the module to revoke access to users as they drop off the AD group. Also, it allows you to add additional users who are not part of the AD groups.

The module is written so that it runs in cron. However, there is a check in the module so it only does it's thing once a day. Therefore, I added a sync-users command to Drush, so you can force a sync whenever you want one.

Attached is a screen shot of the configuration page.

![screen shot 2015-09-14 at 1 45 11 pm](https://cloud.githubusercontent.com/assets/8440187/9858583/21d03bd6-5ae7-11e5-8e53-35b34ee01d52.png)
