### PR TITLE
Change the URL pointing to the IT Handbook

### DIFF
--- a/isushib.module
+++ b/isushib.module
@@ -272,7 +272,7 @@ function isushib_login_link() {
 }
 
 function isushib_ldap_record($netid) {
-  // https://handbook.it.iastate.edu/ch27s02.html#Web_Publishing-Shibboleth-Attributes
+  // https://handbook.it.iastate.edu/ch30s02.html#Web_Publishing-Shibboleth-Attributes
   $attributes = array(
     'uid',
     'mail',


### PR DESCRIPTION
I noticed that the URL of the Shibboleth attributes changed in the IT Handbook, so I modified the comment to point to this updated URL.
