### PR TITLE
LUGG-899 Add hook to update available roles upon role deletion

### DIFF
--- a/isushibsiteaccess.module
+++ b/isushibsiteaccess.module
@@ -185,3 +185,22 @@ function isushibsiteaccess_get_name($fuid) {
   
   return $name;
 }
+
+
+/**
+ * Implements hook_user_role_delete().
+ */
+function isushibsiteaccess_user_role_delete($role) {
+  $role_list = variable_get('isushibsiteaccess_assignable_roles', array());
+  $updated_roles = array();
+  if (in_array($role->rid, $role_list, true)) {
+    foreach ($role_list as $role_key=>$rid) {
+      if ($rid !== $role->rid) {
+        $updated_roles[$rid] = $role_list[$role_key];
+      }
+    }
+    unset($updated_roles[DRUPAL_ANONYMOUS_RID]);
+    unset($updated_roles[DRUPAL_AUTHENTICATED_RID]);
+    variable_set('isushibsiteaccess_assignable_roles', $updated_roles);
+  }
+}


### PR DESCRIPTION
Right now, if you delete a role you get a sizable list of errors if that role was an assignable role.

To test:
- Pull down my changes
- Enable the isushib + isushibsiteaccess modules
- Run drush fra -y and clear all caches (just to be safe)
- Under admin/config/people/isushibsiteaccess/config, allow some roles to be assigned
- Delete one of those roles
- Go back to admin/config/people/isushibsiteaccess
- Is there a giant block of unhappy red messages?
- If you go to admin/config/people/isushibsiteaccess/config again, is Anonymous User unselectable?